### PR TITLE
Added rtc lib, small changes to lib according to watterott

### DIFF
--- a/arduino/samd/libraries/RV8523/RV8523.cpp
+++ b/arduino/samd/libraries/RV8523/RV8523.cpp
@@ -24,13 +24,17 @@
 
 RV8523::RV8523(void)
 {
-  Wire.begin();
-
   return;
 }
 
 
 //-------------------- Public --------------------
+
+
+void RV8523::begin(void)
+{
+  Wire.begin(); //init I2C lib
+}
 
 
 void RV8523::start(void)
@@ -136,7 +140,7 @@ void RV8523::batterySwitchOver(int on) //activate/deactivate battery switch over
     Wire.write(byte(0x02)); //control 3
     if(on)
     {
-      Wire.write(val & ~0xE0); //battery switchover in standard mode
+      Wire.write(val & 0b00111111); //battery switchover in standard mode
     }
     else
     {

--- a/arduino/samd/libraries/RV8523/RV8523.h
+++ b/arduino/samd/libraries/RV8523/RV8523.h
@@ -10,6 +10,7 @@ class RV8523
   public:
     RV8523();
 
+    void begin(void);
     void start(void);
     void stop(void);
     void get(uint8_t *sec, uint8_t *min, uint8_t *hour, uint8_t *day, uint8_t *month, uint16_t *year);

--- a/arduino/samd/libraries/RV8523/examples/Example/Example.ino
+++ b/arduino/samd/libraries/RV8523/examples/Example/Example.ino
@@ -1,0 +1,76 @@
+/*
+  RV8523 RTC (Real-Time-Clock) Example
+
+  Uno       A4 (SDA), A5 (SCL)
+  Mega      20 (SDA), 21 (SCL)
+  Leonardo   2 (SDA),  3 (SCL)
+  
+  Note: To enable the I2C pull-up resistors on the RTC-Breakout, the jumper J1 has to be closed.
+ */
+
+#include <Wire.h>
+#include <RV8523.h>
+
+
+RV8523 rtc;
+
+
+void setup()
+{
+  //init Serial port
+  Serial.begin(9600);
+  while(!Serial); //wait for serial port to connect - needed for Leonardo only
+
+  //init RTC
+  Serial.println("Init RTC...");
+  rtc.begin();
+
+  //set 12 hour mode
+  // rtc.set12HourMode();
+
+  //set 24 hour mode
+  // rtc.set24HourMode();
+
+  //set the date+time (only one time)
+  // rtc.set(0, 0, 8, 24, 12, 2014); //08:00:00 24.12.2014 //sec, min, hour, day, month, year
+
+  //stop/pause RTC
+  // rtc.stop();
+
+  //start RTC
+  rtc.start();
+
+  //When the power source is removed, the RTC will keep the time.
+  rtc.batterySwitchOver(1); //battery switch over on
+
+  //When the power source is removed, the RTC will not keep the time.
+  // rtc.batterySwitchOver(0); //battery switch over off
+}
+
+
+void loop()
+{
+  uint8_t sec, min, hour, day, month;
+  uint16_t year;
+
+  //get time from RTC
+  rtc.get(&sec, &min, &hour, &day, &month, &year);
+
+  //serial output
+  Serial.print("\nTime: ");
+  Serial.print(hour, DEC);
+  Serial.print(":");
+  Serial.print(min, DEC);
+  Serial.print(":");
+  Serial.print(sec, DEC);
+
+  Serial.print("\nDate: ");
+  Serial.print(day, DEC);
+  Serial.print(".");
+  Serial.print(month, DEC);
+  Serial.print(".");
+  Serial.print(year, DEC);
+
+  //wait a second
+  delay(1000);
+}

--- a/arduino/samd/libraries/RV8523/examples/SetClock/SetClock.ino
+++ b/arduino/samd/libraries/RV8523/examples/SetClock/SetClock.ino
@@ -1,0 +1,151 @@
+/*
+  RV8523 RTC (Real-Time-Clock) Set Clock Example
+
+  Uno       A4 (SDA), A5 (SCL)
+  Mega      20 (SDA), 21 (SCL)
+  Leonardo   2 (SDA),  3 (SCL)
+
+  Note: To enable the I2C pull-up resistors on the RTC-Breakout, the jumper J1 has to be closed.
+
+  This sketch allows to set the time using the serial console. On linux use a command like:
+
+    stty -F /dev/ttyUSB1 speed 9600
+    date '+T%H%M%S%d%m%Y' > /dev/ttyUSB1
+
+  to read the current local time from the serial console. Or just type a string like
+
+    T23595924122015
+
+  to set the clock to 23:59:59 24th of December 2015 using Arduinos/Genuinos serial monitor.
+
+  Type an arbitary string not beginning with 'T' to show the current time.
+ */
+
+#include <Wire.h>
+#include <RV8523.h>
+
+
+#define BUFF_MAX 32
+
+RV8523 rtc;
+unsigned int recv_size = 0;
+char recv[BUFF_MAX];
+
+
+void setup()
+{
+  //init Serial port
+  Serial.begin(9600);
+  while(!Serial); //wait for serial port to connect - needed for Leonardo only
+
+  //init RTC
+  Serial.println("Init RTC...");
+  rtc.begin();
+
+  //set 24 hour mode
+  rtc.set24HourMode();
+ 
+  //start RTC
+  rtc.start();
+
+  //When the power source is removed, the RTC will keep the time.
+  rtc.batterySwitchOver(1); //battery switch over on
+}
+
+
+void loop()
+{
+  if (Serial.available() > 0) {
+    setClock();
+  }
+}
+
+
+void setClock()
+{
+  char in;
+
+  in = Serial.read();
+  Serial.print(in); 
+
+  if((in == 10 || in == 13) && (recv_size > 0))
+  {
+    parseCmd(recv, recv_size);
+    printTime();
+    recv_size = 0;
+    recv[0] = 0;
+    return;
+  }
+  else if (in < 48 || in > 122) //ignore ~[0-9A-Za-z]
+  {
+    //do nothing
+  }
+  else if (recv_size > BUFF_MAX - 2) //drop lines that are too long
+  {
+    recv_size = 0;
+    recv[0] = 0;
+  }
+  else if (recv_size < BUFF_MAX - 2)
+  {
+    recv[recv_size] = in;
+    recv[recv_size + 1] = 0;
+    recv_size += 1;
+  }
+}
+
+
+// parse the time string and set the clock accordingly
+void parseCmd(char *cmd, int cmdsize)
+{
+  uint8_t i;
+  uint8_t reg_val;
+  char buff[BUFF_MAX];
+
+  //ThhmmssDDMMYYYY aka set time
+  if (cmd[0] == 84 && cmdsize == 15)
+  {
+    rtc.set(
+      (int)inp2toi(cmd, 5),
+      (int)inp2toi(cmd, 3),
+      (int)inp2toi(cmd, 1),
+      (int)inp2toi(cmd, 7),
+      (int)inp2toi(cmd, 9),
+      (int)inp2toi(cmd, 11) * 100 + inp2toi(cmd, 13)
+    ); //sec, min, hour, day, month, year
+    Serial.println("OK");
+  }
+}
+
+
+// just output the time
+void printTime()
+{
+  uint8_t sec, min, hour, day, month;
+  uint16_t year;
+  
+  //get time from RTC
+  rtc.get(&sec, &min, &hour, &day, &month, &year);
+
+  //serial output
+  Serial.print("\nTime: ");
+  Serial.print(hour, DEC);
+  Serial.print(":");
+  Serial.print(min, DEC);
+  Serial.print(":");
+  Serial.print(sec, DEC);
+
+  Serial.print("\nDate: ");
+  Serial.print(day, DEC);
+  Serial.print(".");
+  Serial.print(month, DEC);
+  Serial.print(".");
+  Serial.print(year, DEC);
+}
+
+
+uint8_t inp2toi(char *cmd, const uint16_t seek)
+{
+  uint8_t rv;
+  rv = (cmd[seek] - 48) * 10 + cmd[seek + 1] - 48;
+  return rv;
+}

--- a/arduino/samd/libraries/RV8523/library.json
+++ b/arduino/samd/libraries/RV8523/library.json
@@ -1,5 +1,6 @@
 {
   "name": "RV8523",
+  "version": "1.0.0",
   "keywords": "i2c, rtc, time, clock",
   "description": "RV-8523 RTC (Real-Time-Clock)",
   "include": "RV8523",


### PR DESCRIPTION
Updated RTC library to comply with the new I2C RTC modul. Changes made in accordance with Watterott
 
```
Hallo,

bitte den Lötjumper auf dem RTC-BOB schließen und in der RV8523.cpp der RV-8523 Library bei

void RV8523::batterySwitchOver(int on)
die Zeile "Wire.write(val & ~0xE0); //battery switchover in standard mode" durch
"Wire.write(val & 0b00111111); //battery switchover in direct switch mode" ändern.

```

closes #31 