### PR TITLE
Try out arduino-cli 0.17.0

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -60,7 +60,7 @@ jobs:
         uses: giantswarm/install-binary-action@5972d5adf093d659091fa22c136a332453247b43
         with:
           binary: "arduino-cli"
-          version: "0.17.0-rc1"
+          version: "0.17.0"
           download_url: "https://github.com/arduino/${binary}/releases/download/${version}/${binary}_${version}_Linux_64bit.tar.gz"
           tarball_binary_path: "${binary}"
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -60,7 +60,7 @@ jobs:
         uses: giantswarm/install-binary-action@5972d5adf093d659091fa22c136a332453247b43
         with:
           binary: "arduino-cli"
-          version: "0.16.1"
+          version: "0.17.0-rc1"
           download_url: "https://github.com/arduino/${binary}/releases/download/${version}/${binary}_${version}_Linux_64bit.tar.gz"
           tarball_binary_path: "${binary}"
 

--- a/.github/workflows/validate-stable.yaml
+++ b/.github/workflows/validate-stable.yaml
@@ -34,7 +34,7 @@ jobs:
         uses: giantswarm/install-binary-action@5972d5adf093d659091fa22c136a332453247b43
         with:
           binary: "arduino-cli"
-          version: "0.16.1"
+          version: "0.17.0"
           download_url: "https://github.com/arduino/${binary}/releases/download/${version}/${binary}_${version}_Linux_64bit.tar.gz"
           tarball_binary_path: "${binary}"
 


### PR DESCRIPTION
This PR bumps the used arduino-cli version to 0.17.0. This doesn't affect the core, just CI