### PR TITLE
Add check for original senseBox MCU package

### DIFF
--- a/.github/ISSUE_TEMAPLTE.md
+++ b/.github/ISSUE_TEMAPLTE.md
@@ -1,0 +1,5 @@
+---
+title: New commits in Watterotts senseBox MCU repository
+assignees: mariopesch
+labels: info
+---

--- a/.github/workflows/mcu-core.yaml
+++ b/.github/workflows/mcu-core.yaml
@@ -1,0 +1,34 @@
+name: Check Watterott senseBox MCU Core for updates
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 1 * * *'  # Check every day
+
+jobs:
+  check-for-updates:
+    name: Check for new commits
+    runs-on: ubuntu-20.04
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          repository: 'watterott/senseBox-MCU'
+          ref: 'master'
+
+      - name: Check for new commits
+        id: check_commits
+        run: |
+          echo "Checking git log"
+          commits=false
+          git shortlog -s --after="yesterday" --before="today" > commits.txt
+          if [[ $(wc -l <commits.txt) -ge 1 ]]
+          then
+            echo "[set-output name=commits;true]"
+          fi
+          echo $commits
+
+      - uses: JasonEtco/create-an-issue@v2
+        if: ${{ steps.check_commits.outputs.commits }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### Description
Added workflow to check Watterotts senseBox MCU repository for new commits. Workflow runs once a day and checks for new commits during yesterday. If there are new commits a new issue with the label `info` will be created and assigned to @mariopesch 

### Why?
We are always missing important changes within the original `senseBox MCU` package by Watterott. Last changed we missed was an update regarding the crypto chip. With this change the senseBox can use The Arduino BearSSL library in combination with the Arduino ECCX08 library and chip to get the SSL certificates. Now with this update there is no need to copy the certificates manually to the MCU. (btw: the most asked support question).