### PR TITLE
fixed battery switchover with closed jumper on pcb

### DIFF
--- a/arduino/samd/libraries/RV8523-RTC-Arduino-Library/src/RV8523.cpp
+++ b/arduino/samd/libraries/RV8523-RTC-Arduino-Library/src/RV8523.cpp
@@ -140,7 +140,7 @@ void RV8523::batterySwitchOver(int on) //activate/deactivate battery switch over
     Wire.write(byte(0x02)); //control 3
     if(on)
     {
-      Wire.write(val & ~0xE0); //battery switchover in standard mode
+      Wire.write(val & 0b00111111); //battery switchover in direct mode
     }
     else
     {


### PR DESCRIPTION
Fixed issue where RTC-Module would not correctly switchover to battery when unpowered. Modification needed on older PCBs, newer PCBs are already shipped with the required solderbrigde closed.